### PR TITLE
fix: allow `>` in style block

### DIFF
--- a/src/core/markdown.ts
+++ b/src/core/markdown.ts
@@ -52,7 +52,7 @@ function extractScriptSetup(html: string) {
 function extractCustomBlock(html: string, options: ResolvedOptions) {
   const blocks: string[] = []
   for (const tag of options.customSfcBlocks) {
-    html = html.replace(new RegExp(`<${tag}[^>]*\\b[^>]*>[^<>]*<\\/${tag}>`, 'gm'), (code) => {
+    html = html.replace(new RegExp(`<${tag}[^>]*\\b[^>]*>[^<]*<\\/${tag}>`, 'gm'), (code) => {
       blocks.push(code)
       return ''
     })


### PR DESCRIPTION
close https://github.com/slidevjs/slidev/issues/1888.

However, this is not a complete fix. If the custom block is something like:

```vue
<custom-block>
  <something />
</custom-block>
```

The regex still can't match because there is a `>` inside the block content.